### PR TITLE
Fix to the Inscription Table bug happening on latest version with Necrotic Burst and Boiling Blood

### DIFF
--- a/src/main/java/net/ender/ess_requiem/spells/blood/BoilingBloodSpell.java
+++ b/src/main/java/net/ender/ess_requiem/spells/blood/BoilingBloodSpell.java
@@ -114,7 +114,12 @@ public class BoilingBloodSpell extends AbstractSpell {
 
     public static float getDamageForAttribute(BoilingBloodSpell spell, LivingEntity entity, int spellLevel, DeferredHolder<Attribute, Attribute> attr1, float modifier)
     {
-        double attrValue1 = entity.getAttributeValue(AttributeRegistry.FIRE_SPELL_POWER);
+        double attrValue1;
+        if(entity != null) {
+            attrValue1 = entity.getAttributeValue(AttributeRegistry.FIRE_SPELL_POWER);
+        }else{
+            attrValue1 = 1;
+        }
 
         float damage = (float) (modifier * (spell.getSpellPower(spellLevel, entity) + attrValue1));
 

--- a/src/main/java/net/ender/ess_requiem/spells/blood/NecroticBurstSpell.java
+++ b/src/main/java/net/ender/ess_requiem/spells/blood/NecroticBurstSpell.java
@@ -130,19 +130,19 @@ public class NecroticBurstSpell extends AbstractSpell {
 
     private float getDamage(int spellLevel, LivingEntity entity)
     {
-        float damage;
-        if(entity != null) {
-            damage = getDamageForAttribute(this, entity, spellLevel, AttributeRegistry.SUMMON_DAMAGE, 1);
-            System.out.println(damage);
-        }else{
-            damage = 19;
-        }
+        float damage = getDamageForAttribute(this, entity, spellLevel, AttributeRegistry.SUMMON_DAMAGE, 1);
+
         return damage;
     }
 
     public static float getDamageForAttribute(NecroticBurstSpell spell, LivingEntity entity, int spellLevel, DeferredHolder<Attribute, Attribute> attr1, float modifier)
     {
-        double attrValue1 = entity.getAttributeValue(AttributeRegistry.SUMMON_DAMAGE);
+        double attrValue1;
+        if(entity != null) {
+            attrValue1 = entity.getAttributeValue(AttributeRegistry.SUMMON_DAMAGE);
+        }else{
+            attrValue1 = 1;
+        }
 
         float damage = (float) (modifier * (spell.getSpellPower(spellLevel, entity) + attrValue1));
 

--- a/src/main/java/net/ender/ess_requiem/spells/blood/NecroticBurstSpell.java
+++ b/src/main/java/net/ender/ess_requiem/spells/blood/NecroticBurstSpell.java
@@ -130,7 +130,13 @@ public class NecroticBurstSpell extends AbstractSpell {
 
     private float getDamage(int spellLevel, LivingEntity entity)
     {
-        float damage = getDamageForAttribute(this, entity, spellLevel, AttributeRegistry.SUMMON_DAMAGE, 1);
+        float damage;
+        if(entity != null) {
+            damage = getDamageForAttribute(this, entity, spellLevel, AttributeRegistry.SUMMON_DAMAGE, 1);
+            System.out.println(damage);
+        }else{
+            damage = 19;
+        }
         return damage;
     }
 


### PR DESCRIPTION
When scaling off of attribute values the player uses, the entity given to the visual info method is just null, so it causes the bug that we see here. I've added a null check when getting attribute values from the player so that it is normally unaffected but when viewed from an inscription table, it will use default attribute values when displaying the spell's stats.